### PR TITLE
Lazy evaluate errors, speeding up the parser a LOT

### DIFF
--- a/ometa/test/test_pymeta.py
+++ b/ometa/test/test_pymeta.py
@@ -1109,6 +1109,7 @@ class MakeGrammarTest(unittest.TestCase):
         """
         e = self.assertRaises(ParseError, OMeta.makeGrammar, grammar,
                               "Foo")
+        print e
         self.assertEquals(e.position, 57)
         self.assertEquals(e.error, [("message", "end of input")])
 
@@ -1458,10 +1459,10 @@ class ErrorReportingTests(unittest.TestCase):
 
         #matching "some" means second branch of 'start' is taken
         self.assertEqual(e.position, 23)
-        self.assertEqual(e.error, [('expected', "token", "bananas"),
+        self.assertEqual(set(e.error), {('expected', "token", "bananas"),
                                    ('expected', 'token', "bacon"),
                                    ('expected', "token", "robots"),
-                                   ('expected', "token", "americans")])
+                                   ('expected', "token", "americans")})
 
         e = self.assertRaises(ParseError, g.start,
                               "crazy horse likes mountains")
@@ -1469,11 +1470,11 @@ class ErrorReportingTests(unittest.TestCase):
         #no "some" means first branch of 'start' is taken...
         #but second is also viable
         self.assertEqual(e.position, 18)
-        self.assertEqual(e.error, [('expected', "token", "some"),
+        self.assertEqual(set(e.error), {('expected', "token", "some"),
                                    ('expected', "token", "bananas"),
                                    ('expected', 'token', "bacon"),
                                    ('expected', "token", "robots"),
-                                   ('expected', "token", "americans")])
+                                   ('expected', "token", "americans")})
 
 
     def test_formattedReporting(self):

--- a/ometa/vm_builder.py
+++ b/ometa/vm_builder.py
@@ -1,4 +1,5 @@
 from StringIO import StringIO
+import os.path
 
 from terml.nodes import Term, coerceToTerm, termMaker as t
 
@@ -7,7 +8,7 @@ def writeBytecode(expr):
     print "Gonna compile", expr
     from ometa.grammar import TreeTransformerGrammar
     from ometa.runtime import TreeTransformerBase
-    Compiler = TreeTransformerGrammar.makeGrammar(open("../ometa/vm.parsley").read(),
+    Compiler = TreeTransformerGrammar.makeGrammar(open(os.path.join(os.path.dirname(__file__), "vm.parsley")).read(),
             "Compiler").createParserClass(TreeTransformerBase, {"t": t})
     return Compiler.transform(expr)[0]
 

--- a/terml/nodes.py
+++ b/terml/nodes.py
@@ -11,7 +11,7 @@ class Term(object):
             args = ()
         self.tag = tag
         self.data = data
-        self.args = args
+        self.args = list(args)
         self.span = span
 
     def __eq__(self, other):


### PR DESCRIPTION
From my simple testing with a non-trivial grammar this change gives me roughly a 60% speed boost.