### PR TITLE
Add trove classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,17 @@ setup(
     long_description=open("README").read(),
     packages=["ometa", "terml", "ometa._generated", "terml._generated",
               "ometa.test", "terml.test"],
-    py_modules=["parsley"]
+    py_modules=["parsley"],
+    classifiers=[
+        'Development Status :: 6 - Mature',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'Topic :: Software Development :: Code Generators',
+        'Topic :: Software Development :: Compilers',
+        'Topic :: Software Development :: Interpreters',
+        ],
 )


### PR DESCRIPTION
This will register Parsley as Python3 compatible on PyPI.